### PR TITLE
Fixing Windows Docker install.

### DIFF
--- a/windows-installer/idt-win-installer.ps1
+++ b/windows-installer/idt-win-installer.ps1
@@ -28,8 +28,7 @@ Foreach($i in $EXT_PROGS) {
             rm "git-installer.exe"
         } elseif ($prog_bin -eq "docker") {
             Invoke-WebRequest "https://download.docker.com/win/stable/InstallDocker.msi" -outfile "InstallDocker.msi"
-            msiexec /a InstallDocker.msi /passive | Out-Null
-            rm "InstallDocker.msi"
+            msiexec /i InstallDocker.msi /passive | Out-Null
         } elseif ($prog_bin -eq "kubectl") {
             $kube_version = (Invoke-WebRequest "https://storage.googleapis.com/kubernetes-release/release/stable.txt").Content
             $kube_version = $kube_version -replace "`n|`r"


### PR DESCRIPTION
This PR fixes the broken Docker install in the Windows script. It was a combination of 2 issues:

1. The `/a` was causing the `msiexec` command to install only for the admin user and not the current user.

2. The removal of the `InstallDocker.msi` immediately after calling `msiexec` was causing the `msiexec` to be unable to find the file because `msiexec` is not process blocking.